### PR TITLE
Fix startup crash when compiled with GCC8

### DIFF
--- a/kodi-17.6-gcc8-empty_m_vertex.patch
+++ b/kodi-17.6-gcc8-empty_m_vertex.patch
@@ -1,0 +1,20 @@
+diff --git a/xbmc/guilib/GUIFontTTFGL.cpp b/xbmc/guilib/GUIFontTTFGL.cpp
+index 60296c2311..046c69566d 100644
+--- a/xbmc/guilib/GUIFontTTFGL.cpp
++++ b/xbmc/guilib/GUIFontTTFGL.cpp
+@@ -147,9 +147,12 @@ void CGUIFontTTFGL::LastEnd()
+ #ifdef HAS_GL
+   glPushClientAttrib(GL_CLIENT_VERTEX_ARRAY_BIT);
+ 
+-  glColorPointer   (4, GL_UNSIGNED_BYTE, sizeof(SVertex), (char*)&m_vertex[0] + offsetof(SVertex, r));
+-  glVertexPointer  (3, GL_FLOAT        , sizeof(SVertex), (char*)&m_vertex[0] + offsetof(SVertex, x));
+-  glTexCoordPointer(2, GL_FLOAT        , sizeof(SVertex), (char*)&m_vertex[0] + offsetof(SVertex, u));
++  if (!m_vertex.empty())
++  {
++    glColorPointer   (4, GL_UNSIGNED_BYTE, sizeof(SVertex), (char*)&m_vertex[0] + offsetof(SVertex, r));
++    glVertexPointer  (3, GL_FLOAT        , sizeof(SVertex), (char*)&m_vertex[0] + offsetof(SVertex, x));
++    glTexCoordPointer(2, GL_FLOAT        , sizeof(SVertex), (char*)&m_vertex[0] + offsetof(SVertex, u));
++  }
+   glEnableClientState(GL_COLOR_ARRAY);
+   glEnableClientState(GL_VERTEX_ARRAY);
+   glEnableClientState(GL_TEXTURE_COORD_ARRAY);

--- a/kodi.spec
+++ b/kodi.spec
@@ -98,6 +98,7 @@ BuildRequires: fontconfig-devel
 BuildRequires: fontpackages-devel
 BuildRequires: freetype-devel
 BuildRequires: fribidi-devel
+BuildRequires: gcc-c++
 %if 0%{?el6}
 BuildRequires: gettext-devel
 %else

--- a/kodi.spec
+++ b/kodi.spec
@@ -51,6 +51,9 @@ Patch2: kodi-17a2-libdvd.patch
 # FFmpeg 3.5 support
 Patch3: kodi-17.6-ffmpeg-3.5.patch
 
+# Prevent panic when compiled with GCC8
+Patch4: kodi-17.6-gcc8-empty_m_vertex.patch
+
 # Optional deps (not in EPEL)
 %if 0%{?fedora}
 # (libbluray in EPEL 6 is too old.)
@@ -278,6 +281,7 @@ cp -p %{SOURCE4} tools/depends/target/libdvdcss/libdvdcss-master.tar.gz
 %patch2 -p1 -b.libdvd
 %endif
 %patch3 -p1 -b.ffmpeg-3.5
+%patch4 -p1 -b.gcc8-mvertex
 
 
 %build


### PR DESCRIPTION
Kodi crashes during the splash screen on Fedora 28. This extra check makes sure we return before evaluating an empty vector.

Full detail: https://trac.kodi.tv/ticket/17850