### PR TITLE
Fix broken boolean requires

### DIFF
--- a/kodi.spec
+++ b/kodi.spec
@@ -212,8 +212,8 @@ BuildRequires: zlib-devel
 
 # Install major backends, users can remove them individually
 Requires: %{name}-common = %{version}
-Requires: %{name}-wayland = %{version} if libwayland-server
-Requires: %{name}-x11 = %{version} if xorg-x11-server-Xorg
+Requires: (%{name}-wayland = %{version} if libwayland-server)
+Requires: (%{name}-x11 = %{version} if xorg-x11-server-Xorg)
 
 
 %description


### PR DESCRIPTION
DEBUG util.py:439:  Error: 
DEBUG util.py:439:   Problem 1: package kodi-devel-18.0-0.7.b1.fc30.x86_64 requires kodi(x86-64) = 18.0-0.7.b1.fc30, but none of the providers can be installed
DEBUG util.py:439:    - conflicting requests
DEBUG util.py:439:    - nothing provides if needed by kodi-18.0-0.7.b1.fc30.x86_64
DEBUG util.py:439:   Problem 2: package kodi-platform-devel-18.0-0.3.20180302gite8574b8.fc30.x86_64 requires kodi-devel(x86-64) >= 18.0, but none of the providers can be installed
DEBUG util.py:439:    - package kodi-devel-18.0-0.7.b1.fc30.x86_64 requires kodi(x86-64) = 18.0-0.7.b1.fc30, but none of the providers can be installed
DEBUG util.py:439:    - conflicting requests
DEBUG util.py:439:    - nothing provides if needed by kodi-18.0-0.7.b1.fc30.x86_6